### PR TITLE
[datapipe]: fix seed for 2nd shuffle on samples

### DIFF
--- a/touchnet/data/datapipe.py
+++ b/touchnet/data/datapipe.py
@@ -83,7 +83,7 @@ class TouchDatapipe(IterableDataset, Stateful):
             # 2nd shuffle on samples
             num_samples = len(_dataset)
             g = torch.Generator()
-            g.manual_seed(self.epoch)
+            g.manual_seed(self.epoch + self.consumed_lists)
             if self.config.dataset_shuffling:
                 sample_idxs = torch.randperm(num_samples, generator=g).tolist()
             else:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the logic behind sample shuffling to provide more varied and consistent random ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->