### PR TITLE
[fix]: path.sh CXXFLAGS

### DIFF
--- a/examples/audio/sft/asr/aishell/path.sh
+++ b/examples/audio/sft/asr/aishell/path.sh
@@ -20,7 +20,7 @@ export CUDA_BIN_PATH=$CUDA_HOME
 export CUDA_PATH=$CUDA_HOME
 export CUDA_INC_PATH=$CUDA_HOME/targets/x86_64-linux
 export CFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CFLAGS
-export CXXFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CFLAGS
+export CXXFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CXXFLAGS
 export LDFLAGS=-L$CUDA_HOME/lib64:$CUDA_HOME/lib64/stubs:/usr/lib:/usr/lib64:$LDFLAGS
 export CUDAToolkit_TARGET_DIR=$CUDA_HOME/targets/x86_64-linux
 

--- a/examples/audio/sft/asr/librispeech/path.sh
+++ b/examples/audio/sft/asr/librispeech/path.sh
@@ -20,7 +20,7 @@ export CUDA_BIN_PATH=$CUDA_HOME
 export CUDA_PATH=$CUDA_HOME
 export CUDA_INC_PATH=$CUDA_HOME/targets/x86_64-linux
 export CFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CFLAGS
-export CXXFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CFLAGS
+export CXXFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CXXFLAGS
 export LDFLAGS=-L$CUDA_HOME/lib64:$CUDA_HOME/lib64/stubs:/usr/lib:/usr/lib64:$LDFLAGS
 export CUDAToolkit_TARGET_DIR=$CUDA_HOME/targets/x86_64-linux
 

--- a/examples/debug/path.sh
+++ b/examples/debug/path.sh
@@ -20,7 +20,7 @@ export CUDA_BIN_PATH=$CUDA_HOME
 export CUDA_PATH=$CUDA_HOME
 export CUDA_INC_PATH=$CUDA_HOME/targets/x86_64-linux
 export CFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CFLAGS
-export CXXFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CFLAGS
+export CXXFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CXXFLAGS
 export LDFLAGS=-L$CUDA_HOME/lib64:$CUDA_HOME/lib64/stubs:/usr/lib:/usr/lib64:$LDFLAGS
 export CUDAToolkit_TARGET_DIR=$CUDA_HOME/targets/x86_64-linux
 

--- a/examples/text/pretrain/allenai_c4/path.sh
+++ b/examples/text/pretrain/allenai_c4/path.sh
@@ -20,7 +20,7 @@ export CUDA_BIN_PATH=$CUDA_HOME
 export CUDA_PATH=$CUDA_HOME
 export CUDA_INC_PATH=$CUDA_HOME/targets/x86_64-linux
 export CFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CFLAGS
-export CXXFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CFLAGS
+export CXXFLAGS=-I$CUDA_HOME/targets/x86_64-linux/include:$CXXFLAGS
 export LDFLAGS=-L$CUDA_HOME/lib64:$CUDA_HOME/lib64/stubs:/usr/lib:/usr/lib64:$LDFLAGS
 export CUDAToolkit_TARGET_DIR=$CUDA_HOME/targets/x86_64-linux
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the configuration for compiler flags to ensure that previously set C++ flags remain intact when adding CUDA include paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->