### PR TITLE
[recipe]: wenetspeech nestrq, 50M -> 1B, works better

### DIFF
--- a/examples/audio/pretrain/wenetspeech/config/Llama-3.2-1B.json
+++ b/examples/audio/pretrain/wenetspeech/config/Llama-3.2-1B.json
@@ -1,0 +1,39 @@
+{
+  "architectures": [
+    "LlamaForASR"
+  ],
+  "attn_implementation": "flex_attention",
+  "input_size": 400,
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": null,
+  "eos_token_id": null,
+  "bos_token": null,
+  "eos_token": null,
+  "pad_token": null,
+  "head_dim": 64,
+  "hidden_act": "silu",
+  "hidden_size": 2048,
+  "initializer_range": 0.02,
+  "intermediate_size": 8192,
+  "max_position_embeddings": 131072,
+  "mlp_bias": false,
+  "model_type": "llama",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 16,
+  "num_key_value_heads": 8,
+  "pretraining_tp": 1,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": {
+    "factor": 32.0,
+    "high_freq_factor": 4.0,
+    "low_freq_factor": 1.0,
+    "original_max_position_embeddings": 8192,
+    "rope_type": "llama3"
+  },
+  "rope_theta": 500000.0,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "use_cache": false,
+  "vocab_size": 1024
+}

--- a/examples/audio/pretrain/wenetspeech/run.sh
+++ b/examples/audio/pretrain/wenetspeech/run.sh
@@ -42,8 +42,8 @@ test_sets="test_net test_meeting"
 param_dtype="bfloat16"
 
 seed=2026
-model_config=config/Llama-3.2.json
-exp_id="wenetspeech_1x8192_fullac_cp1_tp1_dp8_pp1_stack5_stride4_flex_packloss_fromscratch_mid_ar_std0.02_acc_normpreproc_wp2k_addpad_cb1024_emb16_pretrain"
+model_config=config/Llama-3.2-1B.json
+exp_id="wenetspeech_1x8192_fullac_cp1_tp1_dp8_pp1_stack5_stride4_flex_packloss_fromscratch_lagre1B_ar_std0.02_acc_normpreproc_wp2k_addpad_cb1024_emb16_pretrain"
 cp=$(echo $exp_id | grep -oP 'cp\d+' | grep -oP '\d+')
 tp=$(echo $exp_id | grep -oP 'tp\d+' | grep -oP '\d+')
 dp=$(echo $exp_id | grep -oP 'dp\d+' | grep -oP '\d+')


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e8894df5-9050-4621-8934-382690f030e9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new configuration for the Llama-based ASR model with updated hyperparameters.
- **Chores**
  - Updated the training script to use the new model configuration and experiment ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->