### PR TITLE
[doc]: add softlink to docs

### DIFF
--- a/docs/audio_pretrain.md
+++ b/docs/audio_pretrain.md
@@ -1,0 +1,1 @@
+../examples/audio/pretrain/README.md

--- a/docs/audio_sft_asr.md
+++ b/docs/audio_sft_asr.md
@@ -1,0 +1,1 @@
+../examples/audio/sft/asr/README.md

--- a/docs/text_pretrain.md
+++ b/docs/text_pretrain.md
@@ -1,0 +1,1 @@
+../examples/text/pretrain/README.md

--- a/examples/audio/pretrain/README.md
+++ b/examples/audio/pretrain/README.md
@@ -1,21 +1,22 @@
 # Results
 
-As for audio pretraining, we adopt the same model structure as in [LlamaForASR](../../../docs/LlamaForASR.md).
+As for audio pretraining, we adopt the same model structure as in [LlamaForASR](https://github.com/xingchensong/TouchNet/blob/main/docs/LlamaForASR.md).
 We use a training-free audio tokenizer called `BEST-RQ`, which uses a randomly initialized codebook and projector to quantize the input audio. Although its method is very simple, it shows impressive results on speech SSL.
 
 <div align="center">
 
-![touchnet_pretrain](../../../assets/touchnet_pretrain.png)
+![touchnet_pretrain](https://github.com/xingchensong/TouchNet/blob/main/assets/touchnet_pretrain.png)
 
 Comparison between [BEST-RQ](https://arxiv.org/pdf/2202.01855), [NEST-RQ](https://arxiv.org/abs/2409.08680) and our proposed `👆 TouchNet` solution.
 
 </div>
 
-Regarding the optimization of the training process, we have made three improvements on the basis of `BEST-RQ`:
+Regarding the optimization of the training process, we have made four improvements on the basis of `BEST-RQ`:
 
 1. **`Next-Token Prediction is ALL YOU NEED`**: We adopt similar NTP behavior that has been proposed in `NEST-RQ`. `NEST-RQ` uses the same training-free tokenizer as `BEST-RQ` but replaces the BERT-style mask with GPT-style mask. It achieves similar or even better performance compared to `BEST-RQ`. Given that the primary design philosophy of TouchNet is that `all designs must give way to scaling` and NTP has been proven effective in scaling, we prefer `NEST-RQ` over `BEST-RQ` here.
-2. **`Convolution-free model arch`**: To scale more efficiently and easily, we further simplify the model structure and training process on the basis of NTP of `NEST-RQ`. For example, here we simply replace the convolutional downsampling module with a linear projector. At the same time, the main structure of the model follows the LLM design. This convolution-free structure enables us to utilize the existing ecosystem more easily. For more discussion about this model architecture, see [LlamaForASR](../../../docs/LlamaForASR.md).
+2. **`Convolution-free model arch`**: To scale more efficiently and easily, we further simplify the model structure and training process on the basis of NTP of `NEST-RQ`. For example, here we simply replace the convolutional downsampling module with a linear projector. At the same time, the main structure of the model follows the LLM design. This convolution-free structure enables us to utilize the existing ecosystem more easily. For more discussion about this model architecture, see [LlamaForASR](https://github.com/xingchensong/TouchNet/blob/main/docs/LlamaForASR.md).
 3. **`Decouple the BEST-RQ tokenization process and the model forward process`**: In addition to simplifying the model structure, we also simplify the training process. As shown in the figure below, previous methods like `BEST-RQ` and `NEST-EQ` couple the tokenizer and the main body of the model. The random projection and Argmin in the speech quantization process run on the GPU. This coupling is not friendly for large-scale parallel training (such as TP/PP). Thanks to the determinism in initialization and the simplicity in computation of the BEST-RQ tokenizer, we move all the tokenization processes to the CPU. By adding num_workers in the dataloader, we can simply achieve a good overlapping between CPU quantization and GPU model forwarding. Under the design of this structure, whether it is pure text input or multimodal input, it has uniformity for the N-D parallel training system, thereby better reusing the existing ecosystem.
+4. **`CMVN-free`**: We neither use the global mean and var norm common in the speech field nor the sentence-level norm. Instead, we use a parameterless layer norm to perform feature dimension normalization on the stacked audio features. This is to reduce inductive bias and achieve better streaming adaptability.
 
 Here we give a pretraining example on wenetspeech (~10000 hours). As shown in the figure below, for both the large model (1B in red) and the small model (50M in orange), the NTP loss curve is smooth. The final dev accuracy is around 35%. Besides, we also observe a good scaling pattern when scaling from the small model (50M) to the large model (1B).
 

--- a/examples/audio/sft/asr/README.md
+++ b/examples/audio/sft/asr/README.md
@@ -1,5 +1,5 @@
 # Results
 
-see [LlamaForASR](../../../../docs/LlamaForASR.md) for a brief introduction.
+see [LlamaForASR](https://github.com/xingchensong/TouchNet/blob/main/docs/LlamaForASR.md) for a brief introduction.
 
 We only reported the results on wenetspeech (~10000h), and did not report on aishell (~100h) / librispeech (~1000h). This is because these two datasets are too small. Even a small model with 50M parameters is very easy to overfit. However, on the wenetspeech dataset, when we scale the model parameters from 50M to 1B, we still did not observe the overfiting phenomenon. 10000 hours might be a better dataset standard for observation and learning scaling.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added new documentation files and symbolic links for audio pretraining and audio SFT ASR examples.
	- Updated audio pretraining documentation with improved descriptions, corrected and expanded references, and clarified model improvements.
	- Changed documentation links to use absolute GitHub URLs for better accessibility.
	- No changes to technical content or application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->