### PR TITLE
[model] use right padding for qwen2audio, support liger for long audio

### DIFF
--- a/touchnet/models/qwen2_audio/__init__.py
+++ b/touchnet/models/qwen2_audio/__init__.py
@@ -1,10 +1,263 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2025, Xingchen Song(sxc19@tsinghua.org.cn)
 
+from typing import Optional, Tuple, Union
+
 import torch
-from transformers.models.qwen2.modeling_qwen2 import Qwen2RMSNorm
+from liger_kernel.transformers import apply_liger_kernel_to_qwen2
+from transformers.cache_utils import Cache
+from transformers.modeling_outputs import BaseModelOutput
 from transformers.models.qwen2_audio import (
     Qwen2AudioConfig, Qwen2AudioForConditionalGeneration)
+from transformers.models.qwen2_audio.modeling_qwen2_audio import (
+    Qwen2AudioCausalLMOutputWithPast, Qwen2AudioEncoder)
+
+from touchnet.bin import TrainConfig
+
+
+def forward_audio_tower(
+    self,
+    input_features,
+    attention_mask=None,
+    head_mask=None,
+    output_attentions=None,
+    output_hidden_states=None,
+    return_dict=None,
+    **kwargs,
+):
+    r"""
+    NOTE(xcsong): This function is a modified version of the `forward` function in `Qwen2AudioEncoder.forward`.
+                  The only difference is that the `forward` function in `Qwen2AudioEncoder.forward`
+                  assumes the input features are padded to the fixed sequence length (30s), but in our case, the input features might be much longer than 30s (e.g. 1 hour).
+                  So we add a slice&repeat operation to the position embedding to make it compatible with variable length input features.
+
+    For input/output arguments, please refer to the `forward` function in `Qwen2AudioEncoder.forward`.
+    """
+
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    # Ignore copy
+    input_features = input_features.to(dtype=self.conv1.weight.dtype, device=self.conv1.weight.device)
+
+    inputs_embeds = torch.nn.functional.gelu(self.conv1(input_features))
+    inputs_embeds = torch.nn.functional.gelu(self.conv2(inputs_embeds))
+
+    inputs_embeds = inputs_embeds.permute(0, 2, 1)
+    embed_pos = self.embed_positions.weight
+
+    # NOTE(xcsong): Slice the position embedding to make it compatible with variable length input features
+    #   This is the only difference from the original forward function
+    seq_len = inputs_embeds.shape[1]
+    embed_pos_len = embed_pos.shape[0]
+    if embed_pos_len >= seq_len:
+        # embed_pos is longer or equal, slice it
+        pos_embeds = embed_pos[None, :seq_len, :]
+    else:
+        # embed_pos is shorter, repeat it to match seq_len
+        repeat_times = seq_len // embed_pos_len
+        remainder = seq_len % embed_pos_len
+        if remainder == 0:
+            # Perfect division, just repeat
+            pos_embeds = embed_pos.repeat(repeat_times, 1)[None, :, :]
+        else:
+            # Need to handle remainder
+            repeated_pos = embed_pos.repeat(repeat_times, 1)
+            # Add the remaining part
+            remaining_pos = embed_pos[:remainder, :]
+            pos_embeds = torch.cat([repeated_pos, remaining_pos], dim=0)[None, :, :]
+
+    hidden_states = inputs_embeds + pos_embeds
+    hidden_states = torch.nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
+
+    encoder_states = () if output_hidden_states else None
+    all_attentions = () if output_attentions else None
+
+    # check if head_mask has a correct number of layers specified if desired
+    if head_mask is not None:
+        assert head_mask.size()[0] == (len(self.layers)), (
+            f"The head_mask should be specified for {len(self.layers)} layers, but it is for {head_mask.size()[0]}."
+        )
+
+    for idx, encoder_layer in enumerate(self.layers):
+        if output_hidden_states and encoder_states is not None:
+            encoder_states = encoder_states + (hidden_states,)
+        # add LayerDrop (see https://arxiv.org/abs/1909.11556 for description)
+        to_drop = False
+        if self.training:
+            dropout_probability = torch.rand([])
+            if dropout_probability < self.layerdrop:  # skip the layer
+                to_drop = True
+
+        # Ignore copy
+        if to_drop:
+            layer_outputs = (None, None)
+        else:
+            if self.gradient_checkpointing and self.training:
+                layer_outputs = self._gradient_checkpointing_func(
+                    encoder_layer.__call__,
+                    hidden_states,
+                    attention_mask,
+                    (head_mask[idx] if head_mask is not None else None),
+                    output_attentions,
+                )
+            else:
+                layer_outputs = encoder_layer(
+                    hidden_states,
+                    attention_mask,
+                    layer_head_mask=(head_mask[idx] if head_mask is not None else None),
+                    output_attentions=output_attentions,
+                )
+
+            hidden_states = layer_outputs[0]
+
+        if output_attentions and all_attentions is not None:
+            all_attentions = all_attentions + (layer_outputs[1],)
+
+    # Ignore copy
+    hidden_states = hidden_states.permute(0, 2, 1)
+    hidden_states = self.avg_pooler(hidden_states)
+    hidden_states = hidden_states.permute(0, 2, 1)
+
+    hidden_states = self.layer_norm(hidden_states)
+    if output_hidden_states and encoder_states is not None:
+        encoder_states = encoder_states + (hidden_states,)
+
+    if not return_dict:
+        return tuple(v for v in [hidden_states, encoder_states, all_attentions] if v is not None)
+    return BaseModelOutput(
+        last_hidden_state=hidden_states, hidden_states=encoder_states, attentions=all_attentions
+    )
+
+
+def forward(
+    self,
+    input_ids: Optional[torch.LongTensor] = None,
+    input_features: Optional[torch.FloatTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    feature_attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[Cache] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    **kwargs,
+) -> Union[Tuple, Qwen2AudioCausalLMOutputWithPast]:
+    r"""
+    NOTE (xcsong): The liger kernel requires `shift_labels` to calculate loss,
+                   and Qwen2AudioForConditionalGeneration forward function has no `shift_labels` argument
+                   So add **kwargs to `forward` to pass it, which is the first difference from
+                   the standard Qwen2AudioForConditionalGeneration forward function.
+
+                   The second difference is that we use a modified version of the `forward` function for `Qwen2AudioEncoder`
+                   to support variable length input features (see `forward_audio_tower`).
+
+                   The third difference is that we force the `is_causal` attribute of the self-attention layer in `audio_tower` and `language_model` to be True,
+                   and force the `attention_implementation` attribute of `audio_tower` and `language_model` to be "sdpa". This is to make both
+                   `audio_tower` and `language_model` to be streamable and memory efficient.
+
+    For input/output arguments, please refer to original `Qwen2AudioForConditionalGeneration.forward`.
+    """
+
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    target_device = self.audio_tower.device
+
+    if input_features is not None:
+        input_features = input_features.to(target_device)
+        feature_attention_mask = feature_attention_mask.to(target_device)
+
+    if inputs_embeds is None:
+        # 1. Extract the input embeddings
+        inputs_embeds = self.get_input_embeddings()(input_ids)
+
+        # 2. Merge text and audios
+        if input_features is not None and input_ids is not None and input_ids.shape[1] != 1:
+            audio_feat_lengths, audio_output_lengths = self.audio_tower._get_feat_extract_output_lengths(
+                feature_attention_mask.sum(-1)
+            )
+
+            assert self.config._attn_implementation == "sdpa", "sdpa is required"
+            for layer in self.audio_tower.layers:
+                layer.self_attn.is_causal = True
+            audio_outputs = self.audio_tower(input_features)
+            selected_audio_feature = audio_outputs.last_hidden_state
+            audio_features = self.multi_modal_projector(selected_audio_feature)
+
+            # if we have consecutive audio tokens, then it means we expanded input_ids in processing
+            audio_tokens = input_ids == self.config.audio_token_id
+            legacy_processing = (audio_tokens[:, :-1] & audio_tokens[:, 1:]).sum() == 0
+            assert not legacy_processing, "legacy_processing should be False"
+
+            num_audios, max_audio_tokens, embed_dim = audio_features.shape
+            audio_features_mask = torch.arange(max_audio_tokens, device=audio_output_lengths.device)[None, :]
+            audio_features_mask = audio_features_mask < audio_output_lengths[:, None]
+            audio_features = audio_features[audio_features_mask]  # [total_valid_audio_tokens, embed_dim], one-dimensional arrangement
+
+            n_audio_tokens = (input_ids == self.config.audio_token_id).sum().item()
+            n_audio_features = audio_features.shape[0]
+
+            if n_audio_tokens != n_audio_features:
+                print(f"Audio features and audio tokens mismatch detected:")
+                print(f"  n_audio_tokens: {n_audio_tokens}")
+                print(f"  n_audio_features: {n_audio_features}")
+                print(f"  difference: {abs(n_audio_tokens - n_audio_features)}")
+
+                if n_audio_tokens > n_audio_features:
+                    missing_features = n_audio_tokens - n_audio_features
+                    print(f"  Applying padding: adding {missing_features} audio features")
+                    last_feature = audio_features[-1:].expand(missing_features, -1)
+                    audio_features = torch.cat([audio_features, last_feature], dim=0)
+                else:
+                    raise ValueError(
+                        f"Audio features exceed audio tokens: tokens: {n_audio_tokens}, features {n_audio_features}. "
+                        f"This would result in information loss. Please check the audio processing pipeline."
+                    )
+            special_audio_mask = (input_ids == self.config.audio_token_id).to(inputs_embeds.device)
+            special_audio_mask = special_audio_mask.unsqueeze(-1).expand_as(inputs_embeds)  # [batch_size, seq_len, embed_dim]
+            audio_features = audio_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(special_audio_mask, audio_features)
+
+    if self.training or inputs_embeds.shape[0] == 1:
+        # NOTE(xcsong): Training use right padding while inference use left padding, attention mask can be ignored in training but not in inference.
+        assert self.config._attn_implementation == "sdpa", "sdpa is required"
+        for layer in self.language_model.model.layers:
+            layer.self_attn.is_causal = True
+        attention_mask = None
+    outputs = self.language_model(
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+        **kwargs,
+    )
+
+    return outputs
+
+
+def pre_init(args: TrainConfig):
+    """Pre-initialization function for Qwen2AudioForConditionalGeneration."""
+    if args.training_enable_liger_kernel:
+        # 1. monkey patch the forward function to Qwen2Model
+        apply_liger_kernel_to_qwen2()
+        # 2. monkey patch the forward function of Qwen2AudioEncoder
+        Qwen2AudioEncoder.forward = forward_audio_tower
+        # 3. monkey patch the forward function to Qwen2AudioForConditionalGeneration
+        Qwen2AudioForConditionalGeneration.forward = forward
 
 
 def post_init(model: Qwen2AudioForConditionalGeneration, init_device: torch.device):
@@ -24,11 +277,8 @@ def post_init(model: Qwen2AudioForConditionalGeneration, init_device: torch.devi
     model.language_model.model.rotary_emb.inv_freq = inv_freq
     model.language_model.model.rotary_emb.attention_scaling = attention_scaling
     model.language_model.model.rotary_emb.original_inv_freq = inv_freq
-    assert isinstance(model.language_model.model.norm, Qwen2RMSNorm)
     torch.nn.init.ones_(model.language_model.model.norm.weight)
     for layer in model.language_model.model.layers:
-        assert isinstance(layer.input_layernorm, Qwen2RMSNorm)
-        assert isinstance(layer.post_attention_layernorm, Qwen2RMSNorm)
         torch.nn.init.ones_(layer.input_layernorm.weight)
         torch.nn.init.ones_(layer.post_attention_layernorm.weight)
 

--- a/touchnet/models/qwen2_audio/inference_qwen2_audio.py
+++ b/touchnet/models/qwen2_audio/inference_qwen2_audio.py
@@ -25,16 +25,21 @@ torchrun --nproc_per_node=8 --nnodes=1 \
 
 """
 
+import gc
 import json
 import os
 
 import torch
 import torch.distributed as dist
+from liger_kernel.transformers import apply_liger_kernel_to_qwen2
+from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader, DistributedSampler
 from tqdm import tqdm
-from transformers import AutoProcessor, Qwen2AudioForConditionalGeneration
+from transformers import (AutoProcessor, Qwen2AudioEncoder,
+                          Qwen2AudioForConditionalGeneration)
 from transformers.hf_argparser import HfArgumentParser
 
+from touchnet.models.qwen2_audio import forward, forward_audio_tower
 from touchnet.models.qwen2_audio.processing_qwen2_audio import \
     QWEN2_AUDIO_TEMPLATE_FOR_S2T
 from touchnet.utils.distributed import TORCH_DTYPE_MAP
@@ -45,6 +50,15 @@ if __name__ == "__main__":
     parser = HfArgumentParser([InferenceConfig])
     (args,) = parser.parse_args_into_dataclasses()
     os.makedirs(args.output_dir, exist_ok=True)
+
+    if args.inference_enable_liger_kernel:
+        # 1. monkey patch the forward function to Qwen2Model
+        apply_liger_kernel_to_qwen2()
+        # 2. monkey patch the forward function of Qwen2AudioEncoder
+        Qwen2AudioEncoder.forward = forward_audio_tower
+        # 3. monkey patch the forward function to Qwen2AudioForConditionalGeneration
+        Qwen2AudioForConditionalGeneration.forward = forward
+
     processor = AutoProcessor.from_pretrained(
         args.model_path,
         trust_remote_code=True
@@ -78,19 +92,69 @@ if __name__ == "__main__":
 
     writer = open(f"{args.output_dir}/part_{rank + 1}_of_{world_size}", "w")
     for infos, audios in dataloader:
-        prompts = [QWEN2_AUDIO_TEMPLATE_FOR_S2T.replace("<|INSTRUCT|>", args.instruct)] * len(infos)
-        inputs = processor(
-            text=prompts,
-            audio=audios,
-            return_tensors="pt",
-            sampling_rate=processor.feature_extractor.sampling_rate,
-            padding=True
-        )
+        input_ids_buf, attention_mask_buf = [], []
+        input_features_buf, feature_attention_mask_buf = [], []
+        for i, audio in enumerate(audios):
+            audio_inputs = processor.feature_extractor(
+                audio,
+                sampling_rate=processor.feature_extractor.sampling_rate,
+                truncation=False if args.inference_enable_liger_kernel else True,
+                return_attention_mask=True,
+                padding="max_length",
+                return_tensors="pt"
+            )
+            feature_attention_mask = audio_inputs.pop('attention_mask').squeeze(0)
+            if audio_inputs['input_features'].shape[-1] > 3000:
+                feature_attention_mask = torch.ones(audio_inputs['input_features'].shape[-1],
+                                                    dtype=feature_attention_mask.dtype,
+                                                    device=feature_attention_mask.device)
+            text = QWEN2_AUDIO_TEMPLATE_FOR_S2T.replace("<|INSTRUCT|>", args.instruct)
+            audio_length = feature_attention_mask.sum().long()
+            input_length = (audio_length - 1) // 2 + 1
+            num_audio_tokens_expanded = (input_length - 2) // 2 + 1
+            expanded_audio_token = "<|AUDIO|>" * int(num_audio_tokens_expanded.item())
+            expanded_text = text.replace("<|AUDIO|>", expanded_audio_token, 1)
+            text_inputs = processor.tokenizer(
+                expanded_text,
+                padding=False,
+                return_tensors="pt"
+            )
+            input_ids_buf.append(text_inputs['input_ids'].squeeze(0))  # [seq_len,]
+            attention_mask_buf.append(text_inputs['attention_mask'].squeeze(0))  # [seq_len,]
+            input_features_buf.append(audio_inputs['input_features'].squeeze(0).transpose(0, 1))  # [3000 or longer, 128]
+            feature_attention_mask_buf.append(feature_attention_mask)
+
+        inputs = {
+            "input_ids": pad_sequence(input_ids_buf,
+                                      batch_first=True,
+                                      padding_side='left',
+                                      padding_value=processor.tokenizer.pad_token_id),
+            "attention_mask": pad_sequence(attention_mask_buf,
+                                           batch_first=True,
+                                           padding_side='left',
+                                           padding_value=0),
+            "input_features": pad_sequence(input_features_buf,
+                                           batch_first=True,
+                                           padding_side='right',
+                                           padding_value=0).transpose(1, 2),  # [B, 128, T]
+            "feature_attention_mask": pad_sequence(feature_attention_mask_buf,
+                                                   batch_first=True,
+                                                   padding_side='right',
+                                                   padding_value=0),
+        }
+
+        max_length = args.max_length
+        if inputs["input_ids"].shape[1] > max_length:
+            print(f"input_ids.shape[1] > max_length: {inputs['input_ids'].shape[1]} > {max_length}, skip")
+            continue
+
         for k in inputs.keys():
             inputs[k] = inputs[k].cuda()
         with torch.no_grad():
-            generated_ids = model.generate(**inputs, max_length=2048, use_cache=True)
-        generated_ids = generated_ids[:, inputs.input_ids.size(1):]
+            generated_ids = model.generate(**inputs,
+                                           max_length=max_length,
+                                           use_cache=True)
+        generated_ids = generated_ids[:, inputs["input_ids"].size(1):]
         response = processor.batch_decode(
             generated_ids,
             skip_special_tokens=True,
@@ -103,6 +167,10 @@ if __name__ == "__main__":
                     "predict": response[i],
                 }, ensure_ascii=False) + "\n"
             )
+        del inputs
+        # clear cache
+        torch.cuda.empty_cache()
+        gc.collect()
         if rank == 0:
             progress_bar.update(world_size * len(infos))
 

--- a/touchnet/models/qwen2_audio/processing_qwen2_audio.py
+++ b/touchnet/models/qwen2_audio/processing_qwen2_audio.py
@@ -9,6 +9,7 @@ from transformers.models.qwen2_audio.processing_qwen2_audio import \
 
 from touchnet.data import DataConfig
 from touchnet.data.datapipe import LowLevelTouchDatapipe, MidLevelTouchDatapipe
+from touchnet.utils.logging import logger
 
 QWEN2_AUDIO_TEMPLATE_FOR_S2T = "<|audio_bos|><|AUDIO|><|audio_eos|><|INSTRUCT|>"
 
@@ -34,30 +35,69 @@ def dynamic_batch(data, config: DataConfig, processor: Qwen2AudioProcessor):
     longest_length = 0
     for sample in data:
         assert 'waveform' in sample
-        assert 'instruct' in sample  # i.e., Generate the transcription
-        assert 'response' in sample  # i.e., Hello World
+
+        # NOTE(xcsong): if instruct or response is not in sample, we assume it is an asr task
+        if 'instruct' not in sample:
+            sample['instruct'] = "Generate the transcription:"
+        if 'response' not in sample:
+            if 'txt' in sample:
+                sample['response'] = sample['txt']
+            else:
+                logger.info(f"txt not in sample, skip this sample {sample}")
+                continue
+
         audio = sample['waveform'].squeeze(0).numpy()
         sample['instruct'] = QWEN2_AUDIO_TEMPLATE_FOR_S2T.replace("<|INSTRUCT|>", sample['instruct'])
-        # NOTE(xcsong): processor will automatically expand prompt to include instruct_ids and audio_ids
-        prompt = processor(text=sample['instruct'],
-                           audio=audio,
-                           sampling_rate=processor.feature_extractor.sampling_rate,
-                           return_tensors="pt")
+
         # NOTE(xcsong): Qwen2Audio add a pooling layer on top of whisper encoder,
         #               results in 1/4 subsample:
         # Example prompt (a 4 sencond audio with caption `glass is breaking`):
-        #   prompt['input_ids'], torch.Size([1, 109]), <eos> not included
-        #   prompt['attention_mask'], torch.Size([1, 109]), padding mask, all ones
-        #   prompt['input_features'], torch.Size([1, 128, 3000]), whisper encoder input, always padding to 30s
-        #   prompt['feature_attention_mask'], torch.Size([1, 3000]), whisper encoder input
-        input_features = prompt['input_features'].squeeze(0)
-        feature_attention_mask = prompt['feature_attention_mask'].squeeze(0)
-        prompt_ids = prompt['input_ids'].squeeze(0)
+        #   text_inputs['input_ids'], torch.Size([1, 109]), <eos> not included
+        #   text_inputs['attention_mask'], torch.Size([1, 109]), padding mask, all ones
+        #   audio_inputs['input_features'], torch.Size([1, 128, 3000 or longer]), whisper encoder input
+        #   audio_inputs['attention_mask'], torch.Size([1, 3000 or longer]), whisper encoder input
+
+        # NOTE(xcsong): we add truncation=False to support long audio, for audio less than 30s,
+        #               feature_extractor will pad to 30s as usual, for audio longer than 30s,
+        #               feature_extractor will keep it unchanged.
+        audio_inputs = processor.feature_extractor(
+            audio,
+            sampling_rate=processor.feature_extractor.sampling_rate,
+            truncation=False,
+            return_attention_mask=True,
+            padding="max_length",
+            return_tensors="pt"
+        )
+        # NOTE(xcsong): WhisperFeatureExtractor has bug, it will return a wrong feature_attention_mask
+        #               when audio is longer than 30s, so we use a all-ones tensor instead.
+        feature_attention_mask = audio_inputs.pop('attention_mask').squeeze(0)
+        if audio_inputs['input_features'].shape[-1] > 3000:
+            feature_attention_mask = torch.ones(audio_inputs['input_features'].shape[-1],
+                                                dtype=feature_attention_mask.dtype,
+                                                device=feature_attention_mask.device)
+        text = sample['instruct']
+        audio_length = feature_attention_mask.sum().long()
+        input_length = (audio_length - 1) // 2 + 1
+        num_audio_tokens_expanded = (input_length - 2) // 2 + 1
+        expanded_audio_token = "<|AUDIO|>" * int(num_audio_tokens_expanded.item())
+        expanded_text = text.replace("<|AUDIO|>", expanded_audio_token, 1)
+        text_inputs = processor.tokenizer(
+            expanded_text,
+            padding=False,
+            return_tensors="pt"
+        )
+
+        if audio_length * 10 > config.audio_max_length_in_ms_for_filter:
+            logger.info(f"audio_length: {audio_length * 10}ms > config.audio_max_length_in_ms_for_filter: {config.audio_max_length_in_ms_for_filter}ms, skip this sample")  # noqa
+            continue
+
+        input_features = audio_inputs['input_features'].squeeze(0).transpose(0, 1)  # [3000 or longer, 128]
+        prompt_ids = text_inputs['input_ids'].squeeze(0)  # [seq_len,]
         response_ids = torch.tensor(
             processor.tokenizer(sample['response'], add_special_tokens=False).input_ids,
-            dtype=prompt['input_ids'].dtype,
+            dtype=prompt_ids.dtype,
         )
-        eos = torch.tensor([processor.tokenizer.eos_token_id], dtype=prompt['input_ids'].dtype)
+        eos = torch.tensor([processor.tokenizer.eos_token_id], dtype=prompt_ids.dtype)
 
         input_ids = torch.cat((prompt_ids, response_ids))
         labels = torch.cat((torch.zeros_like(prompt_ids[1:]) - 100, response_ids, eos))  # ignore_idx == -100
@@ -65,40 +105,45 @@ def dynamic_batch(data, config: DataConfig, processor: Qwen2AudioProcessor):
 
         new_sample_length = input_ids.size(0)
         if new_sample_length < config.text_min_length_in_tokens_for_filter:
+            logger.info(f"sample_length: {new_sample_length} < config.text_min_length_in_tokens_for_filter: {config.text_min_length_in_tokens_for_filter}, skip this sample")  # noqa
             continue
         if new_sample_length > config.text_max_length_in_tokens_for_filter:
+            logger.info(f"sample_length: {new_sample_length} > config.text_max_length_in_tokens_for_filter: {config.text_max_length_in_tokens_for_filter}, skip this sample")  # noqa
             continue
 
         longest_length = max(longest_length, new_sample_length)
         size_after_padding = longest_length * (len(input_ids_buf) + 1)
         if size_after_padding > (config.dataset_batchsize * config.dataset_text_seqlen):
-            # NOTE(xcsong): set paddingside to left to align with original impl, see
-            #   https://github.com/huggingface/transformers/blob/v4.51.3/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py#L785
+            # NOTE(xcsong): right padding for training, left padding for inference
             yield {
                 "input_ids": pad_sequence(input_ids_buf,
                                           batch_first=True,
-                                          padding_side='left',
+                                          padding_side='right',
                                           padding_value=processor.tokenizer.pad_token_id),
                 "attention_mask": pad_sequence(attention_mask_buf,
                                                batch_first=True,
-                                               padding_side='left',
+                                               padding_side='right',
                                                padding_value=0),
                 "labels": pad_sequence(labels_buf,
                                        batch_first=True,
-                                       padding_side='left',
+                                       padding_side='right',
                                        padding_value=-100),
+                "shift_labels": pad_sequence(labels_buf,
+                                             batch_first=True,
+                                             padding_side='right',
+                                             padding_value=-100),
                 "input_features": pad_sequence(input_features_buf,
                                                batch_first=True,
-                                               padding_side='left',
-                                               padding_value=0),
+                                               padding_side='right',
+                                               padding_value=0).transpose(1, 2),  # [B, 128, T]
                 "feature_attention_mask": pad_sequence(feature_attention_mask_buf,
                                                        batch_first=True,
-                                                       padding_side='left',
+                                                       padding_side='right',
                                                        padding_value=0),
                 "num_sentence": len(input_ids_buf),
                 "sentence_lens": pad_sequence(sentence_lens_buf,
                                               batch_first=True,
-                                              padding_side='left',
+                                              padding_side='right',
                                               padding_value=1),  # 1 for avoid dividing zero
             }
             input_ids_buf, attention_mask_buf, labels_buf = [input_ids], [torch.ones_like(labels)], [labels]
@@ -117,28 +162,32 @@ def dynamic_batch(data, config: DataConfig, processor: Qwen2AudioProcessor):
         yield {
             "input_ids": pad_sequence(input_ids_buf,
                                       batch_first=True,
-                                      padding_side='left',
+                                      padding_side='right',
                                       padding_value=processor.tokenizer.pad_token_id),
             "attention_mask": pad_sequence(attention_mask_buf,
                                            batch_first=True,
-                                           padding_side='left',
+                                           padding_side='right',
                                            padding_value=0),
             "labels": pad_sequence(labels_buf,
                                    batch_first=True,
-                                   padding_side='left',
+                                   padding_side='right',
                                    padding_value=-100),
+            "shift_labels": pad_sequence(labels_buf,
+                                         batch_first=True,
+                                         padding_side='right',
+                                         padding_value=-100),
             "input_features": pad_sequence(input_features_buf,
                                            batch_first=True,
-                                           padding_side='left',
-                                           padding_value=0),
+                                           padding_side='right',
+                                           padding_value=0).transpose(1, 2),  # [B, 128, T]
             "feature_attention_mask": pad_sequence(feature_attention_mask_buf,
                                                    batch_first=True,
-                                                   padding_side='left',
+                                                   padding_side='right',
                                                    padding_value=0),
             "num_sentence": len(input_ids_buf),
             "sentence_lens": pad_sequence(sentence_lens_buf,
                                           batch_first=True,
-                                          padding_side='left',
+                                          padding_side='right',
                                           padding_value=1),  # 1 for avoid dividing zero
         }
 

--- a/touchnet/utils/inference.py
+++ b/touchnet/utils/inference.py
@@ -89,6 +89,12 @@ class InferenceConfig:
             "help": ("Whether to apply Liger kernel to the model"),
         },
     )
+    max_length: int = field(
+        default=70000,
+        metadata={
+            "help": ("Maximum length for generation"),
+        },
+    )
 
 
 class AudioDataset(Dataset):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for variable-length audio inputs, allowing processing of audio longer than 30 seconds.
  * Integrated liger kernel optimizations for improved streaming and memory efficiency.
  * Introduced a configurable maximum generation length for inference.

* **Improvements**
  * Enhanced batching and padding logic for both audio and text inputs.
  * Improved handling of missing or incomplete sample data during batch processing.
  * Updated memory management during inference for better resource utilization.

* **Bug Fixes**
  * Addressed issues with feature attention masks for long audio inputs.
  * Fixed padding inconsistencies in batched tensors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->